### PR TITLE
Add environment variables that can be used in hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Configuration for `deploy` is handled by adding configuration to your `package.j
 		"dest": "user@host:/path/to/directory",
 		"name": "Host #1",
 		"alias": "host-1",
+		"env": (object),
 		"preHooks": (array or string),
 		"postHooks": (array or string)
 	}, ... ],

--- a/deploy.js
+++ b/deploy.js
@@ -58,6 +58,11 @@ co(function* () {
 	if (args.delete) conf.delete = args.delete
 	if (args.dryRun) conf.dryRun = args.dryRun
 
+	// set environment variables
+	for (const envName in parsed.env) {
+		process.env[envName] = parsed.env[envName]
+	}
+
 	console.log('Command:', yield getCommand(conf))
 	let run = true
 	if (args.confirm) {

--- a/lib.js
+++ b/lib.js
@@ -52,9 +52,14 @@ module.exports.parseConfig = co.wrap(function* (args, conf) {
 	// destination-specific hooks are executed between general hooks
 	const preHooks = arrify(conf.preHooks).concat(arrify(destination.preHooks))
 	const postHooks = arrify(destination.postHooks).concat(arrify(conf.postHooks))
+	const env = Object.assign({
+		DEPLOY_ALIAS: destination.alias,
+		DEPLOY_NAME: destination.name,
+	}, conf.env, destination.env)
 
-	conf = Object.assign(setup, omit(conf, [ 'postHooks', 'preHooks' ]),
-		omit(destination, [ 'alias', 'name', 'postHooks', 'preHooks' ]))
+	const omitKeys = [ 'postHooks', 'preHooks', 'env' ]
+	conf = Object.assign(setup, omit(conf, omitKeys),
+		omit(destination, [ 'alias', 'name' ].concat(omitKeys)))
 
 	if (typeof conf.dest === 'undefined')
 		throw new Error(`No destination found. Available aliases: ${conf.destinations.map(d => d.alias)}`)
@@ -62,6 +67,7 @@ module.exports.parseConfig = co.wrap(function* (args, conf) {
 	delete conf.destinations // remove destinations just in case
 	return {
 		config: conf,
+		env,
 		preHooks,
 		postHooks,
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -41,12 +41,20 @@ describe('deploy', () => {
 			dest: 'some-directory/',
 			src: './test',
 			args: [ '-r' ],
+			env: {
+				NODE_ENV: 'production',
+			},
 		}).then((conf) => {
 			expect(conf).to.deep.equal({
 				config: {
 					args: [ '-r' ],
 					dest: 'some-directory/',
 					src: './test',
+				},
+				env: {
+					DEPLOY_ALIAS: undefined,
+					DEPLOY_NAME: undefined,
+					NODE_ENV: 'production',
 				},
 				postHooks: [],
 				preHooks: [],
@@ -70,6 +78,10 @@ describe('deploy', () => {
 					dest: './temp',
 					src: './',
 				},
+				env: {
+					DEPLOY_ALIAS: 'test',
+					DEPLOY_NAME: undefined,
+				},
 				postHooks: [],
 				preHooks: [],
 			})
@@ -91,6 +103,10 @@ describe('deploy', () => {
 					args: [ '-r', '--checksum' ],
 					dest: '../backup',
 					src: './',
+				},
+				env: {
+					DEPLOY_ALIAS: 'spec',
+					DEPLOY_NAME: 'Specific',
 				},
 				postHooks: [],
 				preHooks: [],
@@ -117,6 +133,10 @@ describe('deploy', () => {
 					exclude: '.git*',
 					src: './',
 				},
+				env: {
+					DEPLOY_ALIAS: 'hooks',
+					DEPLOY_NAME: undefined,
+				},
 				postHooks: [ "echo 'post'", "echo 'last'" ],
 				preHooks: [ "echo 'first'", "echo 'pre'" ],
 			})
@@ -142,6 +162,10 @@ describe('deploy', () => {
 					dryRun: true,
 					src: './',
 				},
+				env: {
+					DEPLOY_ALIAS: 'hooks',
+					DEPLOY_NAME: undefined,
+				},
 				postHooks: [ "echo 'post'", "cat /tmp/post", "echo 'last'" ],
 				preHooks: [ "echo 'first'", "cat /tmp/pre", "echo 'pre'" ],
 			})
@@ -153,6 +177,7 @@ describe('deploy', () => {
 		return parse({}, {
 			destinations: [ {
 				alias: 'dest',
+				dryRun: true,
 				name: 'First Destination',
 			}, {
 				alias: 'real',
@@ -165,6 +190,10 @@ describe('deploy', () => {
 					args: [],
 					dest: './not-actually/a-real/path',
 					src: './',
+				},
+				env: {
+					DEPLOY_ALIAS: 'real',
+					DEPLOY_NAME: 'Real Destination',
 				},
 				postHooks: [],
 				preHooks: [],
@@ -185,6 +214,10 @@ describe('deploy', () => {
 					dest: '/',
 					dryRun: true,
 					src: './root',
+				},
+				env: {
+					DEPLOY_ALIAS: undefined,
+					DEPLOY_NAME: undefined,
 				},
 				postHooks: [],
 				preHooks: [],


### PR DESCRIPTION
By default, the `DEPLOY_NAME` and `DEPLOY_ALIAS` are set based on the name and alias of a destination.